### PR TITLE
Ricochet, scopes, and secret ammo fix

### DIFF
--- a/lua/cw/shared/ammotypes/am_ultramegamatchammo.lua
+++ b/lua/cw/shared/ammotypes/am_ultramegamatchammo.lua
@@ -8,10 +8,6 @@ att.statModifiers = {AimSpreadMult = -0.99}
 if CLIENT then
 	att.displayIcon = surface.GetTextureID("atts/matchgradeammo")
 	att.description = {
-		{t = "ur gay lol", c = CustomizableWeaponry.textColors.VNEGATIVE},
-		{t = "i kiss you on the lips", c = CustomizableWeaponry.textColors.VPOSITIVE},
-		{t = "i love you", c = CustomizableWeaponry.textColors.VPOSITIVE},
-		{t = "oh god im gonna cum", c = CustomizableWeaponry.textColors.VPOSITIVE},
 		{t = "hello buy Intravenous :)", c = CustomizableWeaponry.textColors.VPOSITIVE},
 	}
 end

--- a/lua/cw/shared/attachments/md_nightforce_nxs.lua
+++ b/lua/cw/shared/attachments/md_nightforce_nxs.lua
@@ -111,11 +111,6 @@ if CLIENT then
 				surface.SetDrawColor(255, 255, 255, 255)
 				surface.SetTexture(reticle)
 				surface.DrawTexturedRect(0, 0, size, size)
-				
-				if alpha < 1 then
-					self:drawLensShadow(size, size)
-				end
-				
 				surface.SetDrawColor(150 * light[1], 150 * light[2], 150 * light[3], 255 * alpha)
 				surface.SetTexture(lens)
 				surface.DrawTexturedRectRotated(size * 0.5, size * 0.5, size, size, 90)

--- a/lua/weapons/cw_base/sh_bullets.lua
+++ b/lua/weapons/cw_base/sh_bullets.lua
@@ -138,7 +138,7 @@ function SWEP:FireBullet(damage, cone, clumpSpread, bullets)
 						bul.Src = trace.HitPos
 						bul.Dir = Dir2
 						bul.Spread 	= Vec0
-						bul.Tracer	= 0
+						bul.Tracer	= 3
 						bul.Force	= damage * 0.225
 						bul.Damage = bul.Damage * 0.75
 						

--- a/lua/weapons/cw_l115/shared.lua
+++ b/lua/weapons/cw_l115/shared.lua
@@ -230,11 +230,6 @@ if CLIENT then
 				surface.SetDrawColor(255, 255, 255, 255)
 				surface.SetTexture(reticle)
 				surface.DrawTexturedRect(0, 0, size, size)
-				
-				if alpha < 1 then
-					self:drawLensShadow(size, size)
-				end
-				
 				surface.SetDrawColor(150 * light[1], 150 * light[2], 150 * light[3], 255 * alpha)
 				surface.SetTexture(lens)
 				surface.DrawTexturedRectRotated(size * 0.5, size * 0.5, size, size, 90)


### PR DESCRIPTION
Adds tracer to ricochet bullets, removes annoying scope shadow effect on 2 scopes, and removes inappropriate text from secret ammo