### PR TITLE
Fix failed bone lookup

### DIFF
--- a/lua/weapons/cw_base/cl_model.lua
+++ b/lua/weapons/cw_base/cl_model.lua
@@ -1648,8 +1648,9 @@ function SWEP:DrawWorldModel()
 		wm = self.WMEnt
 		
 		if IsValid(wm) then
-			if IsValid(self.Owner) then
-				pos, ang = GetBonePosition(self.Owner, self.Owner:LookupBone("ValveBiped.Bip01_R_Hand"))
+			local hand = IsValid(self.Owner) and self.Owner:LookupBone("ValveBiped.Bip01_R_Hand")
+			if hand then
+				pos, ang = GetBonePosition(self.Owner, hand)
 				
 				if pos and ang then
 					RotateAroundAxis(ang, Right(ang), self.WMAng[1])

--- a/lua/weapons/cw_base/cl_model.lua
+++ b/lua/weapons/cw_base/cl_model.lua
@@ -1648,7 +1648,9 @@ function SWEP:DrawWorldModel()
 		wm = self.WMEnt
 		
 		if IsValid(wm) then
-			local hand = IsValid(self.Owner) and self.Owner:LookupBone("ValveBiped.Bip01_R_Hand")
+			local owner = self:GetOwner()
+			local hand = IsValid(owner) and owner:LookupBone("ValveBiped.Bip01_R_Hand")
+
 			if hand then
 				pos, ang = GetBonePosition(self.Owner, hand)
 				

--- a/lua/weapons/cw_base/cl_model.lua
+++ b/lua/weapons/cw_base/cl_model.lua
@@ -1652,7 +1652,8 @@ function SWEP:DrawWorldModel()
 			local hand = IsValid(owner) and owner:LookupBone("ValveBiped.Bip01_R_Hand")
 
 			if hand then
-				pos, ang = GetBonePosition(self.Owner, hand)
+				pos, ang = GetBonePosition(owner, hand)
+
 				
 				if pos and ang then
 					RotateAroundAxis(ang, Right(ang), self.WMAng[1])


### PR DESCRIPTION
Attempts to fix:
```
[chucks_weaponry_2.0] addons/chucks_weaponry_2.0/lua/weapons/cw_base/cl_model.lua:1652: bad argument #2 to 'GetBonePosition' (number expected, got no value)
  1. GetBonePosition - [C]:-1
   2. unknown - addons/chucks_weaponry_2.0/lua/weapons/cw_base/cl_model.lua:1652 (x78)
```