### PR TITLE
Fix cl_model error

### DIFF
--- a/lua/weapons/cw_base/cl_model.lua
+++ b/lua/weapons/cw_base/cl_model.lua
@@ -78,8 +78,13 @@ function SWEP:GetTracerOrigin()
 	if self.dt.State == CW_AIMING and self.SimulateCenterMuzzle then
 		return self.CenterPos
 	end
+
+	local attachmentTbl = self:getMuzzlePosition()
+	if not attachmentTbl or not attachmentTbl.Pos then
+		return self:GetPos()
+	end
 	
-	return self:getMuzzlePosition().Pos
+	return attachmentTbl.Pos
 end
 
 function SWEP:FireAnimationEvent(pos, ang, event, name)


### PR DESCRIPTION
https://wiki.facepunch.com/gmod/Entity:GetAttachment doesn't always return a table, it can also return nil

Fixes
```
[chucks_weaponry_2.0] addons/chucks_weaponry_2.0/lua/weapons/cw_base/cl_model.lua:82: attempt to index a nil value
  1. unknown - addons/chucks_weaponry_2.0/lua/weapons/cw_base/cl_model.lua:82
```