### PR TITLE
Crosshair and ricochet fix

### DIFF
--- a/lua/weapons/cw_base/sh_bullets.lua
+++ b/lua/weapons/cw_base/sh_bullets.lua
@@ -138,7 +138,7 @@ function SWEP:FireBullet(damage, cone, clumpSpread, bullets)
 						bul.Src = trace.HitPos
 						bul.Dir = Dir2
 						bul.Spread 	= Vec0
-						bul.Tracer	= 3
+						bul.Tracer	= 0
 						bul.Force	= damage * 0.225
 						bul.Damage = bul.Damage * 0.75
 						

--- a/lua/weapons/cw_base/shared.lua
+++ b/lua/weapons/cw_base/shared.lua
@@ -373,6 +373,9 @@ local invalidPlayerBusyProneFunction = function(self)
 end
 
 function SWEP:Initialize()
+	self.DrawCrosshair = true
+	self.AimSwayIntensity = 0
+	self.ViewModelMovementScale = 0
 	self:SetHoldType(self.NormalHoldType)
 	self:setupBallisticsInformation()
 	self:CalculateEffectiveRange()


### PR DESCRIPTION
Will let people use gmod custom crosshairs on cw, decrease up and down bobbing while moving with ads on cw guns, and resetting the ricochet bullet tracer values to what they used to be in default cw